### PR TITLE
Add GNU-stack notes to assembly files

### DIFF
--- a/libs/util/math.S
+++ b/libs/util/math.S
@@ -392,3 +392,7 @@ Lerror:
 #endif
 
 #endif	// USE_INTEL_ASM
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/libs/util/sys_ia32.S
+++ b/libs/util/sys_ia32.S
@@ -85,3 +85,7 @@ F_BEGIN(Sys_MaskFPUExceptions)
 	ret
 F_END(Sys_MaskFPUExceptions)
 #endif /* USE_INTEL_ASM */
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/libs/video/renderer/sw/d_copy.S
+++ b/libs/video/renderer/sw/d_copy.S
@@ -178,3 +178,7 @@ LLRowLoop:
 
 	ret
 #endif /* USE_INTEL_ASM */
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/libs/video/renderer/sw/d_draw.S
+++ b/libs/video/renderer/sw/d_draw.S
@@ -1046,3 +1046,7 @@ LFDone:
 	ret
 
 #endif	// USE_INTEL_ASM
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/libs/video/renderer/sw/d_parta.S
+++ b/libs/video/renderer/sw/d_parta.S
@@ -485,3 +485,7 @@ LPop1AndDone:
 	jmp		LDone
 
 #endif	// USE_INTEL_ASM
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/libs/video/renderer/sw/d_polysa.S
+++ b/libs/video/renderer/sw/d_polysa.S
@@ -1753,3 +1753,6 @@ LNextTri:
 
 #endif	// USE_INTEL_ASM
 
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/libs/video/renderer/sw/d_scana.S
+++ b/libs/video/renderer/sw/d_scana.S
@@ -98,3 +98,6 @@ Llp:
 
 #endif	// USE_INTEL_ASM
 
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/libs/video/renderer/sw/d_spr8.S
+++ b/libs/video/renderer/sw/d_spr8.S
@@ -909,3 +909,7 @@ LNextSpan:
 	ret
 
 #endif	// USE_INTEL_ASM
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/libs/video/renderer/sw/d_varsa.S
+++ b/libs/video/renderer/sw/d_varsa.S
@@ -203,3 +203,6 @@ C(spr8entryvec_table):	.long	0, C(Spr8Entry2_8), C(Spr8Entry3_8), C(Spr8Entry4_8
 
 #endif	// USE_INTEL_ASM
 
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/libs/video/renderer/sw/fpua.S
+++ b/libs/video/renderer/sw/fpua.S
@@ -153,3 +153,7 @@ F_BEGIN(R_SetFPCW)
 	ret
 F_END(R_SetFPCW)
 #endif /* USE_INTEL_ASM */
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/libs/video/renderer/sw/surf8.S
+++ b/libs/video/renderer/sw/surf8.S
@@ -793,3 +793,7 @@ LPatchLoop8:
 	ret
 
 #endif	// USE_INTEL_ASM
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/libs/video/renderer/sw/sw_raclipa.S
+++ b/libs/video/renderer/sw/sw_raclipa.S
@@ -322,3 +322,6 @@ C(R_Alias_clip_left):
 
 #endif	// USE_INTEL_ASM
 
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/libs/video/renderer/sw/sw_raliasa.S
+++ b/libs/video/renderer/sw/sw_raliasa.S
@@ -246,3 +246,6 @@ Lsavelight:
 
 #endif	// USE_INTEL_ASM
 
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/libs/video/renderer/sw/sw_rdrawa.S
+++ b/libs/video/renderer/sw/sw_rdrawa.S
@@ -847,3 +847,6 @@ LClampP3:
 
 #endif	// USE_INTEL_ASM
 
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/libs/video/renderer/sw/sw_redgea.S
+++ b/libs/video/renderer/sw/sw_redgea.S
@@ -759,3 +759,6 @@ C(R_SurfacePatch):
 
 #endif	// USE_INTEL_ASM
 
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/libs/video/renderer/sw/sw_rvarsa.S
+++ b/libs/video/renderer/sw/sw_rvarsa.S
@@ -87,3 +87,6 @@ C(R_InitVars):
 
 #endif	// USE_INTEL_ASM
 
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/libs/video/renderer/sw/transform.S
+++ b/libs/video/renderer/sw/transform.S
@@ -110,3 +110,7 @@ C(TransformVector):
 	ret
 
 #endif	// USE_INTEL_ASM
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif


### PR DESCRIPTION
In Gentoo we get this kind of warning:
```
 * QA Notice: The following files contain writable and executable sections
 *  Files with such sections will not work properly (or at all!) on some
 *  architectures/operating systems.
 * 
 *    https://wiki.gentoo.org/wiki/Hardened/GNU_stack_quickstart
 * 
 * RWX --- --- usr/lib64/quakeforge/plugins/vid_render_sw.so
```

Currently passing -Wl,-z,noexecstack to workaround, but this PR would fix this and be appreciated.

Please see the [above link](https://wiki.gentoo.org/wiki/Hardened/GNU_stack_quickstart) for more information, I'm not the most familiar with this myself so please verify if there's any issues.