### PR TITLE
[simd] fix build when avx2 is not available, but avx is.

### DIFF
--- a/include/QF/simd/types.h
+++ b/include/QF/simd/types.h
@@ -39,7 +39,7 @@
  */
 typedef double vec3d_t[3];
 
-#ifdef __AVX__
+#ifdef __AVX2__
 /** Four element vector type for horizontal (AOS) vector data.
  *
  * This is used for both vectors (3D and 4D) and quaternions. 3D vectors

--- a/include/QF/simd/vec4d.h
+++ b/include/QF/simd/vec4d.h
@@ -28,7 +28,7 @@
 #ifndef __QF_simd_vec4d_h
 #define __QF_simd_vec4d_h
 
-#ifdef __AVX__
+#ifdef __AVX2__
 #include <immintrin.h>
 
 #include "QF/simd/types.h"

--- a/libs/util/test/test-simd.c
+++ b/libs/util/test/test-simd.c
@@ -48,7 +48,7 @@
 
 #define s05 0.70710678118654757
 
-#ifdef __AVX__
+#ifdef __AVX2__
 typedef  struct {
 	int         line;
 	vec4d_t   (*op) (vec4d_t a, vec4d_t b);
@@ -94,7 +94,7 @@ typedef  struct {
 	mat4f_t     ulp_errors;
 } mq4f_test_t;
 
-#ifdef __AVX__
+#ifdef __AVX2__
 static vec4d_t tvtruncd (vec4d_t v, vec4d_t ignore)
 {
 	return vtruncd (v);
@@ -158,7 +158,7 @@ static vec4f_t tmagnitude3f (vec4f_t v, vec4f_t ignore)
 
 #define T(t...) { __LINE__, t }
 
-#ifdef __AVX__
+#ifdef __AVX2__
 static vec4d_test_t vec4d_tests[] = {
 	// 3D dot products
 	T(dotd, right,   right,   one  ),
@@ -487,7 +487,7 @@ static mq4f_test_t mq4f_tests[] = {
 };
 #define num_mq4f_tests (sizeof (mq4f_tests) / (sizeof (mq4f_tests[0])))
 
-#ifdef __AVX__
+#ifdef __AVX2__
 static int
 run_vec4d_tests (void)
 {
@@ -684,7 +684,7 @@ int
 main (void)
 {
 	int         ret = 0;
-#ifdef __AVX__
+#ifdef __AVX2__
 	ret |= run_vec4d_tests ();
 #endif
 	ret |= run_vec4f_tests ();


### PR DESCRIPTION
This failed with errors such as:
                 from ./include/QF/simd/vec4d.h:32,
                 from libs/util/simd.c:37:
./include/QF/simd/vec4d.h: In function ‘qmuld’:
/usr/lib/gcc/x86_64-pc-linux-gnu/10.3.0/include/avx2intrin.h:1049:1: error: inlining failed in call to ‘always_inline’ ‘_mm256_permute4x64_pd’: target specific option mismatch
 1049 | _mm256_permute4x64_pd (__m256d __X, const int __M)

See https://bugs.gentoo.org/797610