### PR TITLE
Implement clang support

### DIFF
--- a/config.d/compiling.m4
+++ b/config.d/compiling.m4
@@ -29,10 +29,14 @@ AC_LINK_IFELSE(
 )
 AH_VERBATIM([HAVE_C99INLINE],
 [#undef HAVE_C99INLINE
-#ifdef HAVE_C99INLINE
-# define GNU89INLINE
+#ifdef __clang__
+# define GNU89INLINE static
 #else
-# define GNU89INLINE extern
+# ifdef HAVE_C99INLINE
+#  define GNU89INLINE
+# else
+#  define GNU89INLINE extern
+# endif
 #endif])
 
 if test "x$GCC" = xyes; then

--- a/config.d/library_functions.m4
+++ b/config.d/library_functions.m4
@@ -48,20 +48,20 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <dlfcn.h>]], [[int foo = RTLD_DEEP
 ])
 fi
 
-dnl Checks for stricmp/strcasecmp
+#dnl Checks for stricmp/strcasecmp
 #AC_CHECK_FUNC(strcasecmp,
 #	,
 #	AC_CHECK_FUNC(stricmp,
 #		AC_DEFINE(strcasecmp,	stricmp)
 #	)
 #)
-AC_CHECK_FUNC(strcasecmp, strcasecmp=yes, strcasecmp=no)
-if test "x$strcasecmp" = xno; then
-	AC_CHECK_FUNC(stricmp,
-		AC_DEFINE(strcasecmp, stricmp, [Define strcasecmp as stricmp if you have one but not the other]),
-		AC_MSG_ERROR([Neither stricmp nor strcasecmp found])
-	)
-fi
+#AC_CHECK_FUNC(strcasecmp, strcasecmp=yes, strcasecmp=no)
+#if test "x$strcasecmp" = xno; then
+#	AC_CHECK_FUNC(stricmp,
+#		AC_DEFINE(strcasecmp, stricmp, [Define strcasecmp as stricmp if you have one but not the other]),
+#		AC_MSG_ERROR([Neither stricmp nor strcasecmp found])
+#	)
+#fi
 
 dnl Check for vsnprintf
 if test "x$ac_cv_func_vsnprintf" = "xno" -a \
@@ -80,14 +80,14 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[fnmatch();]])],[BUILD_FNMATCH=no
 AM_CONDITIONAL(BUILD_FNMATCH, test "x$BUILD_FNMATCH" = "xyes")
 
 AC_MSG_CHECKING(for opendir)
-AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[opendir();]])],[BUILD_DIRENT=no
+AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[extern void opendir(); opendir();]])],[BUILD_DIRENT=no
 	AC_MSG_RESULT(yes)],[BUILD_DIRENT=yes
 	AC_MSG_RESULT(no)
 ])
 AM_CONDITIONAL(BUILD_DIRENT, test "x$BUILD_DIRENT" = "xyes")
 
 AC_MSG_CHECKING(for getopt_long)
-AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[getopt_long();]])],[BUILD_GETOPT=no
+AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[extern void getopt_long(); getopt_long();]])],[BUILD_GETOPT=no
 	AC_MSG_RESULT(yes)],[BUILD_GETOPT=yes
 	AC_MSG_RESULT(no)
 ])

--- a/config.d/typedefs_structs_compiler.m4
+++ b/config.d/typedefs_structs_compiler.m4
@@ -27,7 +27,7 @@ AH_VERBATIM([HAVE___ATTRIBUTE__],
 
 AC_MSG_CHECKING(for __attribute__ ((visibility)))
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[void foo (void);
-	__attribute__ ((sivibility ("default"))) void foo (void) {}]], [[]])],[AC_DEFINE(HAVE___ATTRIBUTE__VISIBILITY)
+	__attribute__ ((visibility ("default"))) void foo (void) {}]], [[]])],[AC_DEFINE(HAVE___ATTRIBUTE__VISIBILITY)
 	AC_MSG_RESULT(yes)],[AC_MSG_RESULT(no)
 ])
 AH_VERBATIM([HAVE___ATTRIBUTE__VISIBILITY],
@@ -37,6 +37,20 @@ AH_VERBATIM([HAVE___ATTRIBUTE__VISIBILITY],
 # define VISIBLE __attribute__((visibility ("default")))
 #else
 # define VISIBLE
+#endif])
+
+AC_MSG_CHECKING(for __attribute__ ((designated_init)))
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[void foo (void);
+	struct x { char y; } __attribute__ ((designated_init));]], [[]])],[AC_DEFINE(HAVE___ATTRIBUTE__DESIGNATED_INIT)
+	AC_MSG_RESULT(yes)],[AC_MSG_RESULT(no)
+])
+AH_VERBATIM([HAVE___ATTRIBUTE__DESIGNATED_INIT],
+[/* Define this if the GCC designated_init __attribute__ is available */
+#undef HAVE___ATTRIBUTE__DESIGNATED_INIT
+#ifdef HAVE___ATTRIBUTE__DESIGNATED_INIT
+# define DESIGNATED_INIT __attribute__((designated_init))
+#else
+# define DESIGNATED_INIT
 #endif])
 
 if test "x$SYSTYPE" = "xWIN32"; then

--- a/configure.ac
+++ b/configure.ac
@@ -54,7 +54,7 @@ case "$host_os" in
 	;;
 	*)
 		dnl Checks for working -lm
-		AC_CHECK_LIB(m, pow,, AC_MSG_ERROR([math library (-lm) appears broken]))
+		AC_CHECK_LIB(m, lgammaf,, AC_MSG_ERROR([math library (-lm) appears broken]))
 	;;
 esac	
 

--- a/include/QF/Vulkan/render.h
+++ b/include/QF/Vulkan/render.h
@@ -6,10 +6,10 @@
 #endif
 #include <vulkan/vulkan.h>
 
+#ifndef __QFCC__
 #include "QF/cexpr.h"
 #include "QF/simd/types.h"
 
-#ifndef __QFCC__
 #include "QF/darray.h"
 #include "QF/Vulkan/command.h"
 #endif
@@ -142,8 +142,13 @@ typedef struct qfv_attachmentinfo_s {
 } qfv_attachmentinfo_t;
 
 typedef struct qfv_taskinfo_s {
+#ifndef __QFCC__
 	exprfunc_t *func;
 	const exprval_t **params;
+#else
+	void       *func;
+	const void **params;
+#endif
 	void       *param_data;
 } qfv_taskinfo_t;
 

--- a/include/QF/cexpr.h
+++ b/include/QF/cexpr.h
@@ -27,6 +27,10 @@
 #ifndef __QF_expr_h
 #define __QF_expr_h
 
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
+
 #include <stdlib.h>
 
 struct exprval_s;
@@ -57,7 +61,7 @@ typedef struct exprtype_s {
 	binop_t    *binops;
 	unop_t     *unops;
 	void       *data;
-} __attribute__((designated_init)) exprtype_t;
+} DESIGNATED_INIT exprtype_t;
 
 typedef struct exprval_s {
 	exprtype_t *type;

--- a/include/QF/qtypes.h
+++ b/include/QF/qtypes.h
@@ -52,20 +52,23 @@
 typedef uint8_t byte;
 #endif
 
-#if __STDC_VERSION__ < 202000
-#define auto __auto_type
-#ifndef _DEF_BOOL_
-# define _DEF_BOOL_
-// KJB Undefined true and false defined in SciTech's DEBUG.H header
-# ifdef __cplusplus
-#  define __bool_true_false_are_defined
-# endif
-# ifndef __bool_true_false_are_defined
-#  undef true
-#  undef false
-typedef	enum	{false, true} bool;
-# endif
+#if __STDC_VERSION__ < 202000 || defined(__clang__)
+# define auto __auto_type
 #endif
+
+#if __STDC_VERSION__ < 202000
+# ifndef _DEF_BOOL_
+#  define _DEF_BOOL_
+// KJB Undefined true and false defined in SciTech's DEBUG.H header
+#  ifdef __cplusplus
+#   define __bool_true_false_are_defined
+#  endif
+#  ifndef __bool_true_false_are_defined
+#   undef true
+#   undef false
+typedef	enum	{false, true} bool;
+#  endif
+# endif
 #endif
 
 // From mathlib...

--- a/libs/audio/test/Makemodule.am
+++ b/libs/audio/test/Makemodule.am
@@ -4,7 +4,6 @@ EXTRA_PROGRAMS += libs/audio/test/testsound
 
 testaudio_libs= \
 	libs/audio/libQFsound.la \
-	libs/scene/libQFscene.la \
 	libs/ruamoko/libQFruamoko.la \
 	libs/util/libQFutil.la
 

--- a/libs/client/cl_effects.c
+++ b/libs/client/cl_effects.c
@@ -126,7 +126,6 @@ CL_NewDlight (entity_t ent, vec4f_t org, int effects, byte glow_size,
 		if (effects & EF_DIMLIGHT)
 			if (effects & ~EF_DIMLIGHT)
 				radius -= 100;
-		radius = radius;
 
 		switch (effects & (EF_RED | EF_BLUE)) {
 			case EF_RED | EF_BLUE:  color = purple; break;

--- a/libs/console/client.c
+++ b/libs/console/client.c
@@ -571,14 +571,14 @@ draw_input_line (inputline_t *il, draw_charbuffer_t *buffer)
 	char       *src = il->lines[il->edit_line] + il->scroll + 1;
 	size_t      i;
 
-	*dst++ = il->scroll ? '<' | 0x80 : il->lines[il->edit_line][0];
+	*dst++ = il->scroll ? '<' | 0x80U : il->lines[il->edit_line][0];
 	for (i = 0; i < il->width - 2 && *src; i++) {
 		*dst++ = *src++;
 	}
 	while (i++ < il->width - 2) {
 		*dst++ = ' ';
 	}
-	*dst++ = *src ? '>' | 0x80 : ' ';
+	*dst++ = *src ? '>' | 0x80U : ' ';
 }
 
 static void

--- a/libs/console/test/test-buffer.c
+++ b/libs/console/test/test-buffer.c
@@ -141,13 +141,12 @@ static int
 test_3 (void)
 {
 	int         ret = 1;
-	static char text[] = R"(01 don't forget this line
-02 and some more lines here
-03  adsf
-04 adfa
-06 hi there
-06 don't forget there's line 07
-)";
+	static char text[] = "01 don't forget this line\n\
+02 and some more lines here\n\
+03  adsf\n\
+04 adfa\n\
+06 hi there\n\
+06 don't forget there's line 07\n";
 	static uint32_t lengths[] = { 26, 28, 9, 8, 12, 32, 0 };
 	static uint32_t lengths2[] = { 1, 5, 2 };
 

--- a/libs/gamecode/pr_exec.c
+++ b/libs/gamecode/pr_exec.c
@@ -1781,7 +1781,7 @@ op_call:
 			old_val.value = pr->watch->value;
 		}
 	}
-exit_program:
+exit_program:;
 }
 
 #define MM(type) (*((pr_##type##_t *) (mm)))
@@ -1793,6 +1793,7 @@ pr_address_mode (progs_t *pr, const dstatement_t *st, int mm_ind)
 	pr_type_t  *op_a = pr->pr_globals + st->a + PR_BASE (pr, st, A);
 	pr_type_t  *op_b = pr->pr_globals + st->b + PR_BASE (pr, st, B);
 	pr_ptr_t    mm_offs = 0;
+	pr_ptr_t    edict_area = 0;
 
 	switch (mm_ind) {
 		case 0:
@@ -1801,7 +1802,7 @@ pr_address_mode (progs_t *pr, const dstatement_t *st, int mm_ind)
 			break;
 		case 1:
 			// entity.field (equivalent to OP_LOAD_t_v6p)
-			pr_ptr_t    edict_area = pr->pr_edict_area - pr->pr_globals;
+			edict_area = pr->pr_edict_area - pr->pr_globals;
 			mm_offs = edict_area + OPA(entity) + OPB(field);
 			break;
 		case 2:
@@ -1830,6 +1831,7 @@ pr_call_mode (progs_t *pr, const dstatement_t *st, int mm_ind)
 	pr_type_t  *op_a = pr->pr_globals + st->a + PR_BASE (pr, st, A);
 	pr_type_t  *op_b = pr->pr_globals + st->b + PR_BASE (pr, st, B);
 	pr_ptr_t    mm_offs = 0;
+	pr_ptr_t    edict_area = 0;
 
 	switch (mm_ind) {
 		case 1:
@@ -1846,7 +1848,7 @@ pr_call_mode (progs_t *pr, const dstatement_t *st, int mm_ind)
 			break;
 		case 4:
 			// entity.field (equivalent to OP_LOAD_t_v6p)
-			pr_ptr_t    edict_area = pr->pr_edict_area - pr->pr_globals;
+			edict_area = pr->pr_edict_area - pr->pr_globals;
 			mm_offs = edict_area + OPA(entity) + OPB(field);
 			break;
 	}
@@ -2148,6 +2150,9 @@ pr_exec_ruamoko (progs_t *pr, int exitdepth)
 		pr_type_t  *stk;
 		pr_type_t  *mm;
 		pr_func_t   function;
+
+		int         ret_size = 0;
+
 		pr_opcode_e st_op = st->op & OP_MASK;
 		switch (st_op) {
 			// 0 0000
@@ -2547,7 +2552,7 @@ pr_exec_ruamoko (progs_t *pr, int exitdepth)
 				break;
 			OP_cmp_T (LT, U, long, lvec2, lvec4, <, ulong, ulvec2, ulvec4);
 			case OP_RETURN:
-				int         ret_size = (st->c & 0x1f) + 1;	// up to 32 words
+				ret_size = (st->c & 0x1f) + 1;	// up to 32 words
 				if (st->c != 0xffff) {
 					mm = pr_address_mode (pr, st, st->c >> 5);
 					memcpy (&R_INT (pr), mm, ret_size * sizeof (*op_a));
@@ -2876,7 +2881,7 @@ pr_exec_ruamoko (progs_t *pr, int exitdepth)
 			old_val.value = pr->watch->value;
 		}
 	}
-exit_program:
+exit_program:;
 }
 /*
 	PR_ExecuteProgram

--- a/libs/gamecode/pr_parse.c
+++ b/libs/gamecode/pr_parse.c
@@ -219,6 +219,9 @@ ED_ParseEpair (progs_t *pr, pr_type_t *base, pr_def_t *key, const char *s)
 	pr_type_t	*d;
 	dfunction_t	*func;
 
+	vec3_t      vec = {};
+	char       *str = 0;
+
 	d = &base[key->ofs];
 
 	switch (key->type & ~DEF_SAVEGLOBAL) {
@@ -231,8 +234,7 @@ ED_ParseEpair (progs_t *pr, pr_type_t *base, pr_def_t *key, const char *s)
 			break;
 
 		case ev_vector:
-			vec3_t      vec = {};
-			char       *str = alloca (strlen (s) + 1);
+			str = alloca (strlen (s) + 1);
 			strcpy (str, s);
 			for (char *v = str; *v; v++) {
 				if (*v == ',') {
@@ -446,7 +448,6 @@ static void
 ED_SpawnEntities (progs_t *pr, plitem_t *entity_list)
 {
 	edict_t    *ent;
-	int         inhibit = 0;
 	plitem_t   *entity;
 	plitem_t   *item;
 	int         i;
@@ -479,7 +480,6 @@ ED_SpawnEntities (progs_t *pr, plitem_t *entity_list)
 		// remove things from different skill levels or deathmatch
 		if (pr->prune_edict && pr->prune_edict (pr, ent)) {
 			ED_Free (pr, ent);
-			inhibit++;
 			continue;
 		}
 

--- a/libs/gamecode/pr_strings.c
+++ b/libs/gamecode/pr_strings.c
@@ -1070,10 +1070,11 @@ fmt_state_conversion (fmt_state_t *state)
 {
 	progs_t    *pr = state->pr;
 	char        conv;
+	pr_ptr_t    at_param;
 	switch ((conv = *state->c++)) {
 		case '@':
 			// object
-			pr_ptr_t    at_param = P_UINT (pr, state->fmt_count);
+			at_param = P_UINT (pr, state->fmt_count);
 			if (state->at_handler) {
 				const char *at_str = state->at_handler (pr, at_param,
 														state->at_handler_data);

--- a/libs/gamecode/test/main.c
+++ b/libs/gamecode/test/main.c
@@ -30,6 +30,7 @@ static void
 test_debug_handler (prdebug_t event, void *param, void *data)
 {
 	progs_t    *pr = data;
+	dstatement_t *st = 0;
 
 	switch (event) {
 		case prd_breakpoint:
@@ -44,7 +45,7 @@ test_debug_handler (prdebug_t event, void *param, void *data)
 		case prd_subexit:
 			break;
 		case prd_trace:
-			dstatement_t *st = test_pr.pr_statements + test_pr.pr_xstatement;
+			st = test_pr.pr_statements + test_pr.pr_xstatement;
 			if (verbose > 1) {
 				printf ("---\n");
 				printf ("debug: trace %05x %04x %04x %04x %04x%s\n",

--- a/libs/models/brush/vulkan_model_brush.c
+++ b/libs/models/brush/vulkan_model_brush.c
@@ -231,7 +231,6 @@ load_textures (model_t *mod, vulkan_ctx_t *ctx)
 	// to black, no one should notice :)
 	sky_palette[3] = 0;
 
-	size_t      image_count = 0;
 	size_t      memsize = 0;
 	for (unsigned i = 0; i < brush->numtextures; i++) {
 		texture_t  *tx = brush->textures[i];
@@ -240,7 +239,6 @@ load_textures (model_t *mod, vulkan_ctx_t *ctx)
 		}
 		vulktex_t  *tex = tx->render;
 		memsize += QFV_GetImageSize (device, tex->tex->image);
-		image_count++;
 		// just so we have one in the end
 		image = tex->tex->image;
 	}

--- a/libs/scene/light.c
+++ b/libs/scene/light.c
@@ -211,6 +211,7 @@ Light_DecayLights (lightingdata_t *ldata, float frametime, double realtime)
 	}
 }
 
+#if 0
 void
 Light_dyn_light_ui (void *comp, imui_ctx_t *imui_ctx,
 					ecs_registry_t *reg, uint32_t ent, void *data)
@@ -274,3 +275,4 @@ Light_light_ui (void *comp, imui_ctx_t *imui_ctx,
 		UI_Labelf ("%g %g %g %g", VEC4_EXP (light->attenuation));
 	}
 }
+#endif

--- a/libs/scene/scene.c
+++ b/libs/scene/scene.c
@@ -156,13 +156,13 @@ static const component_t scene_components[scene_comp_count] = {
 	[scene_dynlight] = {
 		.size = sizeof (dlight_t),
 		.name = "dyn_light",
-		.ui = Light_dyn_light_ui,
+//		.ui = Light_dyn_light_ui,
 	},
 
 	[scene_light] = {
 		.size = sizeof (light_t),
 		.name = "light",
-		.ui = Light_light_ui,
+//		.ui = Light_light_ui,
 	},
 	[scene_efrags] = {
 		.size = sizeof (efrag_t *),

--- a/libs/scene/test/test-transform.c
+++ b/libs/scene/test/test-transform.c
@@ -482,7 +482,7 @@ test_frames (void)
 int
 main (void)
 {
-	scene_t    *scene = Scene_NewScene ();
+	scene_t    *scene = Scene_NewScene (NULL);
 	reg = scene->reg;
 
 	if (test_single_transform ()) { return 1; }

--- a/libs/ui/imui.c
+++ b/libs/ui/imui.c
@@ -217,10 +217,10 @@ imui_ctx_t *
 IMUI_NewContext (canvas_system_t canvas_sys, const char *font, float fontsize)
 {
 	imui_ctx_t *ctx = malloc (sizeof (imui_ctx_t));
-	uint32_t canvas;
+	uint32_t canvas = Canvas_New (canvas_sys);
 	*ctx = (imui_ctx_t) {
 		.csys = canvas_sys,
-		.canvas = canvas = Canvas_New (canvas_sys),
+		.canvas = canvas,
 		.vsys = { canvas_sys.reg, canvas_sys.view_base },
 		.tsys = { canvas_sys.reg, canvas_sys.view_base, canvas_sys.text_base },
 		.shaper = Shaper_New (),
@@ -792,7 +792,7 @@ IMUI_Layout_SetXSize (imui_ctx_t *ctx, imui_size_t size, int value)
 	auto pcont = View_Control (ctx->current_parent);
 	uint32_t id = ctx->current_parent.id;
 	pcont->semantic_x = size;
-	if (size == imui_size_percent || imui_size_expand) {
+	if (size == imui_size_percent || (bool) imui_size_expand) {
 		*(int *) Ent_AddComponent(id, c_percent_x, ctx->csys.reg) = value;
 	}
 }
@@ -803,7 +803,7 @@ IMUI_Layout_SetYSize (imui_ctx_t *ctx, imui_size_t size, int value)
 	auto pcont = View_Control (ctx->current_parent);
 	uint32_t id = ctx->current_parent.id;
 	pcont->semantic_y = size;
-	if (size == imui_size_percent || imui_size_expand) {
+	if (size == imui_size_percent || (bool) imui_size_expand) {
 		*(int *) Ent_AddComponent(id, c_percent_y, ctx->csys.reg) = value;
 	}
 }

--- a/libs/util/zone.c
+++ b/libs/util/zone.c
@@ -615,9 +615,8 @@ Hunk_Print (memhunk_t *hunk, bool all)
 {
 	if (!hunk) { hunk = global_hunk; } //FIXME clean up callers
 	hunkblk_t  *h, *next, *endlow, *starthigh, *endhigh;
-	int         count, sum, totalblocks;
+	int         sum, totalblocks;
 
-	count = 0;
 	sum = 0;
 	totalblocks = 0;
 
@@ -648,7 +647,6 @@ Hunk_Print (memhunk_t *hunk, bool all)
 		}
 
 		next = (hunkblk_t *) ((byte *) h + h->size);
-		count++;
 		totalblocks++;
 		sum += h->size;
 
@@ -667,7 +665,6 @@ Hunk_Print (memhunk_t *hunk, bool all)
 				Sys_Printf ("          :%8i %*.*s (TOTAL)\n",
 							sum, sz, sz, h->name[0] ? h->name : "unknown");
 			}
-			count = 0;
 			sum = 0;
 		}
 

--- a/libs/video/renderer/vulkan/vulkan_lighting.c
+++ b/libs/video/renderer/vulkan/vulkan_lighting.c
@@ -1250,6 +1250,7 @@ create_light_matrices (lightingctx_t *lctx)
 		auto        lm = &lctx->light_mats.a[r->matrix_id];
 		mat4f_t     view;
 		mat4f_t     proj;
+		vec4f_t     dir;
 
 		switch (r->mode) {
 			default:
@@ -1261,7 +1262,7 @@ create_light_matrices (lightingctx_t *lctx)
 			case ST_CASCADE:
 			case ST_PLANE:
 				//FIXME will fail for -ref_direction
-				vec4f_t     dir = light->direction;
+				dir = light->direction;
 				dir[3] = 0;
 				mat4fquat (view, qrotf (dir, ref_direction));
 				break;

--- a/qw/source/cl_cam.c
+++ b/qw/source/cl_cam.c
@@ -438,22 +438,22 @@ Cam_Track (usercmd_t *cmd)
 	}
 
 	frame = &cl.frames[cls.netchan.incoming_sequence & UPDATE_MASK];
-	if (autocam && cls.demoplayback2 && 0) {
-		if (ideal_track != spec_track && realtime - last_lock > 1
-			&& frame->playerstate[ideal_track].messagenum == cl.parsecount)
-			Cam_Lock (ideal_track);
+	// if (autocam && cls.demoplayback2) {
+	// 	if (ideal_track != spec_track && realtime - last_lock > 1
+	// 		&& frame->playerstate[ideal_track].messagenum == cl.parsecount)
+	// 		Cam_Lock (ideal_track);
 
-		if (frame->playerstate[spec_track].messagenum != cl.parsecount) {
-			int         i;
+	// 	if (frame->playerstate[spec_track].messagenum != cl.parsecount) {
+	// 		int         i;
 
-			for (i = 0; i < MAX_CLIENTS; i++) {
-				if (frame->playerstate[i].messagenum == cl.parsecount)
-					break;
-			}
-			if (i < MAX_CLIENTS)
-				Cam_Lock (i);
-		}
-	}
+	// 		for (i = 0; i < MAX_CLIENTS; i++) {
+	// 			if (frame->playerstate[i].messagenum == cl.parsecount)
+	// 				break;
+	// 		}
+	// 		if (i < MAX_CLIENTS)
+	// 			Cam_Lock (i);
+	// 	}
+	// }
 
 	player = frame->playerstate + spec_track;
 	self = frame->playerstate + cl.playernum;

--- a/qw/source/sv_main.c
+++ b/qw/source/sv_main.c
@@ -1025,19 +1025,16 @@ client_t *
 SV_AllocClient (int spectator, int server)
 {
 	client_t   *cl;
-	int         i, clients, spectators, free, bots;
+	int         i, clients, spectators, free;
 	static int  userid;
 
 	// count up the clients and spectators
 	clients = 0;
 	spectators = 0;
 	free = 0;
-	bots = 0;
 	for (i = 0, cl = svs.clients; i < MAX_CLIENTS; i++, cl++) {
 		if (cl->state == cs_free)
 			free++;
-		else if (cl->state == cs_server)
-			bots++;
 		else if (cl->spectator)
 			spectators++;
 		else

--- a/tools/qfcc/source/value.c
+++ b/tools/qfcc/source/value.c
@@ -87,10 +87,11 @@ ALLOC_STATE (ex_value_t, values);
 static void
 value_debug_handler (prdebug_t event, void *param, void *data)
 {
-	progs_t    *pr = data;
+	progs_t      *pr = data;
+	dstatement_t *st = 0;
 	switch (event) {
 		case prd_trace:
-			dstatement_t *st = pr->pr_statements + pr->pr_xstatement;
+			st = pr->pr_statements + pr->pr_xstatement;
 			PR_PrintStatement (pr, st, 0);
 			break;
 		case prd_breakpoint:

--- a/tools/qfmodelgen/source/trilib.c
+++ b/tools/qfmodelgen/source/trilib.c
@@ -75,7 +75,7 @@ LoadTriangleList (char *filename, triangle_t **pptri, int *numtriangles)
 	QFile       *input;
 	char        name[256], tex[256];
 	float       start, exitpattern;
-	int         count, iLevel, magic, i;
+	int         count, magic, i;
 	tf_triangle	tri;
 	triangle_t	*ptri;
 
@@ -90,8 +90,6 @@ LoadTriangleList (char *filename, triangle_t **pptri, int *numtriangles)
 		fprintf (stderr,"reader: could not open file '%s'\n", filename);
 		exit (0);
 	}
-
-	iLevel = 0;
 
 	Qread(input, &magic, sizeof(int));
 	if (BigLong (magic) != MAGIC) {
@@ -123,7 +121,6 @@ LoadTriangleList (char *filename, triangle_t **pptri, int *numtriangles)
 //				fprintf(stdout,"OBJECT START: %s\n",name);
 				Qread (input, &count, sizeof (int));
 				count = BigLong (count);
-				++iLevel;
 				if (count != 0) {
 //					indent();
 //					fprintf (stdout, "NUMBER OF TRIANGLES: %d\n", count);
@@ -145,7 +142,6 @@ LoadTriangleList (char *filename, triangle_t **pptri, int *numtriangles)
 				/* safe and to provide a little extra information for */
 				/* those who do not wish to write a recursive reader. */
 				/* Mia culpa. */
-				iLevel--;
 				i = -1;
 				do {
 					i++;


### PR DESCRIPTION
Fixing a load of issues related to autoconf and some small source-level issues to re-add clang support. autoconf feature detection probably needs some addressing - partially as -Werror is applied late.

Some workarounds/pokes are required to build with clang for the time being - partially due to a flex bug tripping `-Wmisleading-indentation`. Passing `-Wno-misleading-indentation` on the CLI doesn't work as the QF `-Wall` is specified afterwards so atm it requires a manual fix mid-build.